### PR TITLE
Fix duplicate tool name bug

### DIFF
--- a/app/tools/user_crud.py
+++ b/app/tools/user_crud.py
@@ -27,7 +27,7 @@ def get_users(
     users_dict = [user.model_dump_json() for user in users]
     return json.dumps(users_dict)
 
-@tool("get_users", args_schema=StandardUserSignUp, return_direct=True)
+@tool("create_user", args_schema=StandardUserSignUp, return_direct=True)
 def create_user(
     email: EmailStr,
     username: str,


### PR DESCRIPTION
Accidentally had two tools with the same name, which causes the original tool to be overwritten 